### PR TITLE
Switch to Paper API with ORMLite and Lombok

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,15 +14,19 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
+      <maven.compiler.source>17</maven.compiler.source>
+      <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <repositories>
-    <repository>
-      <id>spigot-repo</id>
-      <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-    </repository>
+      <repository>
+        <id>spigot-repo</id>
+        <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+      </repository>
+      <repository>
+        <id>papermc</id>
+        <url>https://repo.papermc.io/repository/maven-public/</url>
+      </repository>
     <repository>
       <id>placeholderapi</id>
       <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
@@ -31,8 +35,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.spigotmc</groupId>
-      <artifactId>spigot-api</artifactId>
+      <groupId>io.papermc.paper</groupId>
+      <artifactId>paper-api</artifactId>
       <version>1.19.4-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
@@ -51,6 +55,22 @@
       <groupId>com.zaxxer</groupId>
       <artifactId>HikariCP</artifactId>
       <version>5.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.30</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.j256.ormlite</groupId>
+      <artifactId>ormlite-jdbc</artifactId>
+      <version>6.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.mojang</groupId>
+      <artifactId>brigadier</artifactId>
+      <version>1.0.18</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/net/xdproston/tiderep/Files.java
+++ b/src/main/java/net/xdproston/tiderep/Files.java
@@ -2,6 +2,10 @@ package net.xdproston.tiderep;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.util.function.Function;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.configuration.file.YamlConfiguration;
 import net.xdproston.tiderep.logger.Logger;
 import net.xdproston.tiderep.logger.LoggerType;
@@ -24,50 +28,11 @@ public final class Files
             catch (Exception e) {
                 Logger.send(LoggerType.SEVERE, "An error occurred during the creation of the configuration file:" + String.format("%s - %s", e.getClass().getName(), e.getMessage()));
             }
+        }
 
-            try {config.load(file);}
-            catch (Exception e) {
-                Logger.send(LoggerType.SEVERE, "An error occurred while loading the configuration file:" + String.format("%s - %s", e.getClass().getName(), e.getMessage()));
-            }
-
-            config.set("settings.startup-reputation", 0);
-            config.set("settings.dislike-modificator", 1);
-            config.set("settings.like-modificator", 1);
-            config.set("settings.database.type", "sqlite");
-            config.set("settings.database.mysql-ip-and-port", "localhost:3306");
-            config.set("settings.database.mysql-user", "root");
-            config.set("settings.database.mysql-password", "123123");
-            config.set("settings.database.mysql-use-database", "mydb");
-
-            config.set("global-messages.no-perms", "<red>You dont have permission!");
-            config.set("global-messages.only-player", "&cOnly player!");
-            config.set("global-messages.player-not-found", "<red>Player not found!");
-            config.set("global-messages.self-use", "<red>You can't use it on yourself.");
-
-            config.set("commands.reputation.usage", "<white>Usage <grey>- <gold>/%label% <player name> <+/->");
-            config.set("commands.reputation.already", "<white>You've already thrown him a reputation.");
-            config.set("commands.reputation.message.to-sender-up", "<white>You have successfully increased the reputation of the player <gold>%player%<white>.");
-            config.set("commands.reputation.message.to-sender-down", "<white>You have successfully lowered the reputation of the player <gold>%player%<white>.");
-            config.set("commands.reputation.message.to-recipient-up", "<white>The <gold>%player% <white>player has boosted your reputation.");
-            config.set("commands.reputation.message.to-recipient-down", "<white>The <gold>%player% <white>player has lowered your reputation.");
-
-            config.set("commands.areputation.usage", "&f<white>Usage &7<gray>- &6<gold>/%label% <player name> <take/give/set> <amount>");
-            config.set("commands.areputation.take", "&f<white>You have &c<red>removed &f<white>a reputation to the player &6<gold>%player% &f<white>in the amount of &6<gold>%amount%&f<white>.");
-            config.set("commands.areputation.give", "&f<white>You have &a<green>added &f<white>a reputation to the player &6<gold>%player% &f<white>in the amount of &6<gold>%amount%&f<white>.");
-            config.set("commands.areputation.set", "&f<white>You have &e<yellow>set &f<white>a reputation to the player &6<gold>%player% &f<white>in the amount of &6<gold>%amount%&f<white>.");
-
-            config.set("commands.reputationreload.usage", "&f<white>usage&7<grey>: &6<gold>/reputationreload");
-            config.set("commands.reputationreload.reloaded", "&f<white>Plugin successfully reloaded!");
-
-            try {config.save(file);}
-            catch (Exception e) {
-                Logger.send(LoggerType.SEVERE, "An error occurred while loading the configuration file:" + String.format("%s - %s", e.getClass().getName(), e.getMessage()));
-            }
-        } else {
-            try {config.load(file);}
-            catch (Exception e) {
-                Logger.send(LoggerType.SEVERE, "An error occurred while loading the configuration file:" + String.format("%s - %s", e.getClass().getName(), e.getMessage()));
-            }
+        try {config.load(file);}
+        catch (Exception e) {
+            Logger.send(LoggerType.SEVERE, "An error occurred while loading the configuration file:" + String.format("%s - %s", e.getClass().getName(), e.getMessage()));
         }
     }
 
@@ -103,6 +68,17 @@ public final class Files
         }
     }
 
+    private static final MiniMessage MM = MiniMessage.miniMessage();
+
+    public static java.util.function.Function<TagResolver[], Component> messageFunction(String path, String def) {
+        String raw = config.getString(path, def);
+        return resolvers -> MM.deserialize(raw, resolvers);
+    }
+
+    public static Component message(String path, String def, TagResolver... resolvers) {
+        return messageFunction(path, def).apply(resolvers);
+    }
+
     public static final class Config
     {
         public static int STARTUP_REPUTATION;
@@ -123,30 +99,30 @@ public final class Files
                 Logger.send(LoggerType.SEVERE, "An error occurred while loading the configuration file:" + String.format("%s - %s", e.getClass().getName(), e.getMessage()));
             }
 
-            STARTUP_REPUTATION = config.getInt("settings.startup-reputation");
-            DISLIKE_MODIFICATOR = config.getInt("settings.dislike-modificator");
-            LIKE_MODIFICATOR = config.getInt("settings.like-modificator");
-            DATABASE_TYPE = config.getString("settings.database.type");
-            DATABASE_MYSQL_IP_AND_PORT = config.getString("settings.database.mysql-ip-and-port");
-            DATABASE_MYSQL_USER = config.getString("settings.database.mysql-user");
-            DATABASE_MYSQL_PASSWORD = config.getString("settings.database.mysql-password");
-            DATABASE_MYSQL_USE_DB = config.getString("settings.database.mysql-use-database");
-            GLOBAL_NO_PERMISSION = config.getString("global-messages.no-perms");
-            GLOBAL_USE_SELF = config.getString("global-messages.self-use");
-            GLOBAL_ONLY_PLAYER = config.getString("global-messages.only-player");
-            GLOBAL_PLAYER_NOT_FOUND = config.getString("global-messages.player-not-found");
-            REPUTATION_CMD_USAGE = config.getString("commands.reputation.usage");
-            REPUTATION_CMD_ALREADY = config.getString("commands.reputation.already");
-            REPUTATION_CMD_TO_SENDER_UP = config.getString("commands.reputation.message.to-sender-up");
-            REPUTATION_CMD_TO_SENDER_DOWN = config.getString("commands.reputation.message.to-sender-down");
-            REPUTATION_CMD_TO_RECIPIENT_UP = config.getString("commands.reputation.message.to-recipient-up");
-            REPUTATION_CMD_TO_RECIPIENT_DOWN = config.getString("commands.reputation.message.to-recipient-down");
-            AREPUTATION_CMD_USAGE = config.getString("commands.areputation.usage");
-            AREPUTATION_CMD_TAKE = config.getString("commands.areputation.take");
-            AREPUTATION_CMD_GIVE = config.getString("commands.areputation.give");
-            AREPUTATION_CMD_SET = config.getString("commands.areputation.set");
-            REPUTATIONRELOAD_CMD_RELOADED = config.getString("commands.reputationreload.reloaded");
-            REPUTATIONRELOAD_CMD_USAGE = config.getString("commands.reputationreload.usage");
+            STARTUP_REPUTATION = config.getInt("settings.startup-reputation", 0);
+            DISLIKE_MODIFICATOR = config.getInt("settings.dislike-modificator", 1);
+            LIKE_MODIFICATOR = config.getInt("settings.like-modificator", 1);
+            DATABASE_TYPE = config.getString("settings.database.type", "sqlite");
+            DATABASE_MYSQL_IP_AND_PORT = config.getString("settings.database.mysql-ip-and-port", "localhost:3306");
+            DATABASE_MYSQL_USER = config.getString("settings.database.mysql-user", "root");
+            DATABASE_MYSQL_PASSWORD = config.getString("settings.database.mysql-password", "123123");
+            DATABASE_MYSQL_USE_DB = config.getString("settings.database.mysql-use-database", "mydb");
+            GLOBAL_NO_PERMISSION = config.getString("global-messages.no-perms", "<red>You dont have permission!");
+            GLOBAL_USE_SELF = config.getString("global-messages.self-use", "<red>You can't use it on yourself.");
+            GLOBAL_ONLY_PLAYER = config.getString("global-messages.only-player", "&cOnly player!");
+            GLOBAL_PLAYER_NOT_FOUND = config.getString("global-messages.player-not-found", "<red>Player not found!");
+            REPUTATION_CMD_USAGE = config.getString("commands.reputation.usage", "<white>Usage <grey>- <gold>/%label% <player name> <+/->");
+            REPUTATION_CMD_ALREADY = config.getString("commands.reputation.already", "<white>You've already thrown him a reputation.");
+            REPUTATION_CMD_TO_SENDER_UP = config.getString("commands.reputation.message.to-sender-up", "<white>You have successfully increased the reputation of the player <gold>%player%<white>.");
+            REPUTATION_CMD_TO_SENDER_DOWN = config.getString("commands.reputation.message.to-sender-down", "<white>You have successfully lowered the reputation of the player <gold>%player%<white>.");
+            REPUTATION_CMD_TO_RECIPIENT_UP = config.getString("commands.reputation.message.to-recipient-up", "<white>The <gold>%player% <white>player has boosted your reputation.");
+            REPUTATION_CMD_TO_RECIPIENT_DOWN = config.getString("commands.reputation.message.to-recipient-down", "<white>The <gold>%player% <white>player has lowered your reputation.");
+            AREPUTATION_CMD_USAGE = config.getString("commands.areputation.usage", "<white>Usage <gray>- <gold>/%label% <player name> <take/give/set> <amount>");
+            AREPUTATION_CMD_TAKE = config.getString("commands.areputation.take", "<white>You have <red>removed <white>a reputation to the player <gold>%player% <white>in the amount of <gold>%amount%<white>.");
+            AREPUTATION_CMD_GIVE = config.getString("commands.areputation.give", "<white>You have <green>added <white>a reputation to the player <gold>%player% <white>in the amount of <gold>%amount%<white>.");
+            AREPUTATION_CMD_SET = config.getString("commands.areputation.set", "<white>You have <yellow>set <white>a reputation to the player <gold>%player% <white>in the amount of <gold>%amount%<white>.");
+            REPUTATIONRELOAD_CMD_RELOADED = config.getString("commands.reputationreload.reloaded", "<white>Plugin successfully reloaded!");
+            REPUTATIONRELOAD_CMD_USAGE = config.getString("commands.reputationreload.usage", "<white>usage: <gold>/reputationreload");
         }
     }
 }

--- a/src/main/java/net/xdproston/tiderep/Main.java
+++ b/src/main/java/net/xdproston/tiderep/Main.java
@@ -5,7 +5,8 @@ import net.xdproston.tiderep.impl.MySQL;
 import net.xdproston.tiderep.impl.SQLite;
 import net.xdproston.tiderep.interfaces.Database;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.entity.Player;
@@ -37,11 +38,11 @@ public final class Main extends JavaPlugin implements Listener
     @Override
     public void onLoad() {
         ConsoleCommandSender ccs = Bukkit.getConsoleSender();
-
-        ccs.sendMessage(" ");
-        ccs.sendMessage(ChatColor.translateAlternateColorCodes('&', "  &6&lTideReputation &7- &f" + getDescription().getVersion()));
-        ccs.sendMessage(ChatColor.translateAlternateColorCodes('&', "  &fThe plugin is loading..."));
-        ccs.sendMessage(" ");
+        MiniMessage mm = MiniMessage.miniMessage();
+        ccs.sendMessage(Component.empty());
+        ccs.sendMessage(mm.deserialize("<gold><b>TideReputation</b></gold> <gray>-</gray> <white>" + getDescription().getVersion()));
+        ccs.sendMessage(mm.deserialize("<white>The plugin is loading...</white>"));
+        ccs.sendMessage(Component.empty());
     }
 
     private static void initCommands() {

--- a/src/main/java/net/xdproston/tiderep/PapiHook.java
+++ b/src/main/java/net/xdproston/tiderep/PapiHook.java
@@ -1,7 +1,8 @@
 package net.xdproston.tiderep;
 
 import net.xdproston.tiderep.interfaces.Database;
-import org.bukkit.ChatColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
@@ -29,16 +30,20 @@ public class PapiHook extends PlaceholderExpansion
         Database database = Main.getCurrentDatabase();
 
         if (params.equalsIgnoreCase("reputation")) {
-            return database.hasPlayerInDatabase((Player)player) ? String.format("%d", database.getPlayerReputation((Player)player)) : null;
+            return database.hasPlayerInDatabase((Player) player)
+                    ? String.valueOf(database.getPlayerReputation((Player) player))
+                    : null;
         }
 
         if (params.equalsIgnoreCase("advanced_reputation")) {
-            if (!database.hasPlayerInDatabase((Player)player)) return null;
+            if (!database.hasPlayerInDatabase((Player) player)) return null;
 
-            int reputation = database.getPlayerReputation((Player)player);
-            if (reputation == 0) return ChatColor.translateAlternateColorCodes('&', String.format("&e%d", reputation));
-            else if (reputation < 0) return ChatColor.translateAlternateColorCodes('&', String.format("&c%d", reputation));
-            else return ChatColor.translateAlternateColorCodes('&', String.format("&a+%d", reputation));
+            int reputation = database.getPlayerReputation((Player) player);
+            Component comp;
+            if (reputation == 0) comp = MiniMessage.miniMessage().deserialize("<yellow>" + reputation);
+            else if (reputation < 0) comp = MiniMessage.miniMessage().deserialize("<red>" + reputation);
+            else comp = MiniMessage.miniMessage().deserialize("<green>+" + reputation);
+            return MiniMessage.miniMessage().serialize(comp);
         }
 
         return null;

--- a/src/main/java/net/xdproston/tiderep/User.java
+++ b/src/main/java/net/xdproston/tiderep/User.java
@@ -1,0 +1,28 @@
+package net.xdproston.tiderep;
+
+import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.table.DatabaseTable;
+import lombok.Data;
+
+@Data
+@DatabaseTable(tableName = "users")
+public class User {
+    @DatabaseField(id = true)
+    private String name;
+
+    @DatabaseField
+    private int reputation;
+
+    @DatabaseField
+    private String sends;
+
+    public User() {
+        // ORMLite requires no-arg constructor
+    }
+
+    public User(String name, int reputation, String sends) {
+        this.name = name;
+        this.reputation = reputation;
+        this.sends = sends;
+    }
+}

--- a/src/main/java/net/xdproston/tiderep/commands/AReputationCommand.java
+++ b/src/main/java/net/xdproston/tiderep/commands/AReputationCommand.java
@@ -5,95 +5,81 @@ import java.util.List;
 import net.xdproston.tiderep.Main;
 import net.xdproston.tiderep.interfaces.Database;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.*;
 import org.bukkit.entity.Player;
 import com.google.common.collect.Lists;
-import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.audience.Audience;
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.StringArgumentType;
 import net.xdproston.tiderep.Files;
 import org.jetbrains.annotations.NotNull;
 
 public class AReputationCommand implements CommandExecutor, TabCompleter
 {
     private static final Database database = Main.getCurrentDatabase();
-    private static final MiniMessage mm = MiniMessage.miniMessage();
-
-    private static @NotNull String rc(String target) {
-        return ChatColor.translateAlternateColorCodes('&', target);
-    }
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, String[] args) {
-        boolean isPlayer = sender instanceof Player;
-        Audience audience = null;
-
-        if (isPlayer) audience = (Audience)sender;
+        Audience audience = (Audience) sender;
 
         if (args.length < 3) {
-            if (isPlayer) {
-                audience.sendMessage(mm.deserialize(ChatColor.stripColor(Files.Config.AREPUTATION_CMD_USAGE.replace("%label%", label))));
-                return true;
-            }
-            sender.sendMessage(rc(mm.stripTags(Files.Config.AREPUTATION_CMD_USAGE.replace("%label%", label))));
+            audience.sendMessage(Files.message("commands.areputation.usage", Files.Config.AREPUTATION_CMD_USAGE,
+                    Placeholder.parsed("label", label)));
             return true;
         }
 
-        Player target = Bukkit.getPlayer(args[0]);
+        StringReader reader = new StringReader(String.join(" ", args));
+        String targetName;
+        try {
+            targetName = StringArgumentType.word().parse(reader);
+        } catch (com.mojang.brigadier.exceptions.CommandSyntaxException e) {
+            audience.sendMessage(Files.message("commands.areputation.usage", Files.Config.AREPUTATION_CMD_USAGE,
+                    Placeholder.parsed("label", label)));
+            return true;
+        }
+        Player target = Bukkit.getPlayer(targetName);
         if (target == null) {
-            if (isPlayer) {
-                audience.sendMessage(mm.deserialize(ChatColor.stripColor(Files.Config.GLOBAL_PLAYER_NOT_FOUND)));
-                return true;
-            }
-            sender.sendMessage(rc(mm.stripTags(Files.Config.GLOBAL_PLAYER_NOT_FOUND)));
+            audience.sendMessage(Files.message("global-messages.player-not-found", Files.Config.GLOBAL_PLAYER_NOT_FOUND));
             return true;
         }
 
+        String operation;
         int amount;
-        try { amount = Integer.parseInt(args[2]);
+        try {
+            operation = StringArgumentType.word().parse(reader);
+            amount = Integer.parseInt(StringArgumentType.word().parse(reader));
         } catch (Exception e) {
-            if (isPlayer) {
-                audience.sendMessage(mm.deserialize(ChatColor.stripColor(Files.Config.AREPUTATION_CMD_USAGE.replace("%label%", label))));
-                return true;
-            }
-            sender.sendMessage(rc(mm.stripTags(Files.Config.AREPUTATION_CMD_USAGE.replace("%label%", label))));
+            audience.sendMessage(Files.message("commands.areputation.usage", Files.Config.AREPUTATION_CMD_USAGE,
+                    Placeholder.parsed("label", label)));
             return true;
         }
 
-        switch (args[1].toLowerCase()) {
+        switch (operation.toLowerCase()) {
             case "take": {
                 database.setPlayerReputation(target, database.getPlayerReputation(target) - amount);
-                if (isPlayer) {
-                    audience.sendMessage(mm.deserialize(ChatColor.stripColor(Files.Config.AREPUTATION_CMD_TAKE.replace("%player%", target.getName()).replace("%amount%", String.format("%d", amount)))));
-                    return true;
-                }
-                sender.sendMessage(rc(mm.stripTags(Files.Config.AREPUTATION_CMD_TAKE.replace("%player%", target.getName()).replace("%amount%", String.format("%d", amount)))));
+                audience.sendMessage(Files.message("commands.areputation.take", Files.Config.AREPUTATION_CMD_TAKE,
+                        Placeholder.parsed("player", target.getName()),
+                        Placeholder.parsed("amount", String.valueOf(amount))));
                 return true;
             }
             case "give": {
                 database.setPlayerReputation(target, database.getPlayerReputation(target) + amount);
-                if (isPlayer) {
-                    audience.sendMessage(mm.deserialize(ChatColor.stripColor(Files.Config.AREPUTATION_CMD_GIVE.replace("%player%", target.getName()).replace("%amount%", String.format("%d", amount)))));
-                    return true;
-                }
-                sender.sendMessage(rc(mm.stripTags(Files.Config.AREPUTATION_CMD_GIVE.replace("%player%", target.getName()).replace("%amount%", String.format("%d", amount)))));
+                audience.sendMessage(Files.message("commands.areputation.give", Files.Config.AREPUTATION_CMD_GIVE,
+                        Placeholder.parsed("player", target.getName()),
+                        Placeholder.parsed("amount", String.valueOf(amount))));
                 return true;
             }
             case "set": {
                 database.setPlayerReputation(target, amount);
-                if (isPlayer) {
-                    audience.sendMessage(mm.deserialize(ChatColor.stripColor(Files.Config.AREPUTATION_CMD_SET.replace("%player%", target.getName()).replace("%amount%", String.format("%d", amount)))));
-                    return true;
-                }
-                sender.sendMessage(rc(mm.stripTags(Files.Config.AREPUTATION_CMD_SET.replace("%player%", target.getName()).replace("%amount%", String.format("%d", amount)))));
+                audience.sendMessage(Files.message("commands.areputation.set", Files.Config.AREPUTATION_CMD_SET,
+                        Placeholder.parsed("player", target.getName()),
+                        Placeholder.parsed("amount", String.valueOf(amount))));
                 return true;
             }
             default: {
-                if (isPlayer) {
-                    audience.sendMessage(mm.deserialize(ChatColor.stripColor(Files.Config.AREPUTATION_CMD_USAGE.replace("%label%", label))));
-                    return true;
-                }
-                sender.sendMessage(rc(mm.stripTags(Files.Config.AREPUTATION_CMD_USAGE.replace("%label%", label))));
+                audience.sendMessage(Files.message("commands.areputation.usage", Files.Config.AREPUTATION_CMD_USAGE,
+                        Placeholder.parsed("label", label)));
                 return true;
             }
         }

--- a/src/main/java/net/xdproston/tiderep/commands/ReputationCommand.java
+++ b/src/main/java/net/xdproston/tiderep/commands/ReputationCommand.java
@@ -5,7 +5,6 @@ import java.util.List;
 import net.xdproston.tiderep.Main;
 import net.xdproston.tiderep.interfaces.Database;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -14,7 +13,9 @@ import org.bukkit.entity.Player;
 import com.google.common.collect.Lists;
 import net.xdproston.tiderep.Files;
 import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.StringArgumentType;
 import org.jetbrains.annotations.NotNull;
 
 public class ReputationCommand implements CommandExecutor, TabCompleter
@@ -24,46 +25,69 @@ public class ReputationCommand implements CommandExecutor, TabCompleter
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, String[] args) {
         if (!(sender instanceof Player)) {
-            sender.sendMessage(ChatColor.translateAlternateColorCodes('&', Files.Config.GLOBAL_ONLY_PLAYER));
+            ((Audience) sender).sendMessage(Files.message("global-messages.only-player", Files.Config.GLOBAL_ONLY_PLAYER));
             return true;
         }
 
-        Audience cmdSender = (Audience)sender;
+        Audience cmdSender = (Audience) sender;
         if (args.length < 2) {
-            cmdSender.sendMessage(MiniMessage.miniMessage().deserialize(Files.Config.REPUTATION_CMD_USAGE.replace("%label%", label)));
+            cmdSender.sendMessage(Files.message("commands.reputation.usage", Files.Config.REPUTATION_CMD_USAGE,
+                    Placeholder.parsed("label", label)));
             return true;
         }
 
-        Player target = Bukkit.getPlayer(args[0]);
+        StringReader reader = new StringReader(String.join(" ", args));
+        String targetName;
+        try {
+            targetName = StringArgumentType.word().parse(reader);
+        } catch (com.mojang.brigadier.exceptions.CommandSyntaxException e) {
+            cmdSender.sendMessage(Files.message("commands.reputation.usage", Files.Config.REPUTATION_CMD_USAGE,
+                    Placeholder.parsed("label", label)));
+            return true;
+        }
+        Player target = Bukkit.getPlayer(targetName);
         if (target == null) {
-            cmdSender.sendMessage(MiniMessage.miniMessage().deserialize(Files.Config.GLOBAL_PLAYER_NOT_FOUND));
+            cmdSender.sendMessage(Files.message("global-messages.player-not-found", Files.Config.GLOBAL_PLAYER_NOT_FOUND));
             return true;
         }
         if (target == sender) {
-            cmdSender.sendMessage(MiniMessage.miniMessage().deserialize(Files.Config.GLOBAL_USE_SELF));
+            cmdSender.sendMessage(Files.message("global-messages.self-use", Files.Config.GLOBAL_USE_SELF));
             return true;
         }
 
         if (database.containsPlayerInSends((Player)sender, target)) {
-            cmdSender.sendMessage(MiniMessage.miniMessage().deserialize(Files.Config.REPUTATION_CMD_ALREADY));
+            cmdSender.sendMessage(Files.message("commands.reputation.already", Files.Config.REPUTATION_CMD_ALREADY));
             return true;
         }
 
-        if (args[1].equalsIgnoreCase("+")) {
+        String operation;
+        try {
+            operation = StringArgumentType.word().parse(reader);
+        } catch (com.mojang.brigadier.exceptions.CommandSyntaxException e) {
+            cmdSender.sendMessage(Files.message("commands.reputation.usage", Files.Config.REPUTATION_CMD_USAGE,
+                    Placeholder.parsed("label", label)));
+            return true;
+        }
+        if (operation.equalsIgnoreCase("+")) {
             database.setPlayerReputation(target, database.getPlayerReputation(target) + Files.Config.LIKE_MODIFICATOR);
-            cmdSender.sendMessage(MiniMessage.miniMessage().deserialize(Files.Config.REPUTATION_CMD_TO_SENDER_UP.replace("%player%", target.getName())));
-            ((Audience)target).sendMessage(MiniMessage.miniMessage().deserialize(Files.Config.REPUTATION_CMD_TO_RECIPIENT_UP.replace("%player%", sender.getName())));
+            cmdSender.sendMessage(Files.message("commands.reputation.message.to-sender-up", Files.Config.REPUTATION_CMD_TO_SENDER_UP,
+                    Placeholder.parsed("player", target.getName())));
+            ((Audience) target).sendMessage(Files.message("commands.reputation.message.to-recipient-up", Files.Config.REPUTATION_CMD_TO_RECIPIENT_UP,
+                    Placeholder.parsed("player", sender.getName())));
             database.addPlayerToSends((Player)sender, target);
             return true;
-        } else if (args[1].equalsIgnoreCase("-")) {
+        } else if (operation.equalsIgnoreCase("-")) {
             database.setPlayerReputation(target, database.getPlayerReputation(target) - Files.Config.DISLIKE_MODIFICATOR);
-            cmdSender.sendMessage(MiniMessage.miniMessage().deserialize(Files.Config.REPUTATION_CMD_TO_SENDER_DOWN.replace("%player%", target.getName())));
-            ((Audience)target).sendMessage(MiniMessage.miniMessage().deserialize(Files.Config.REPUTATION_CMD_TO_RECIPIENT_DOWN.replace("%player%", sender.getName())));
+            cmdSender.sendMessage(Files.message("commands.reputation.message.to-sender-down", Files.Config.REPUTATION_CMD_TO_SENDER_DOWN,
+                    Placeholder.parsed("player", target.getName())));
+            ((Audience) target).sendMessage(Files.message("commands.reputation.message.to-recipient-down", Files.Config.REPUTATION_CMD_TO_RECIPIENT_DOWN,
+                    Placeholder.parsed("player", sender.getName())));
             database.addPlayerToSends((Player)sender, target);
             return true;
         }
 
-        cmdSender.sendMessage(MiniMessage.miniMessage().deserialize(Files.Config.REPUTATION_CMD_USAGE.replace("%label%", label)));
+        cmdSender.sendMessage(Files.message("commands.reputation.usage", Files.Config.REPUTATION_CMD_USAGE,
+                Placeholder.parsed("label", label)));
         return true;
     }
 

--- a/src/main/java/net/xdproston/tiderep/commands/ReputationReloadCommand.java
+++ b/src/main/java/net/xdproston/tiderep/commands/ReputationReloadCommand.java
@@ -1,10 +1,8 @@
 package net.xdproston.tiderep.commands;
 
 import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.xdproston.tiderep.Files;
 import net.xdproston.tiderep.Main;
-import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -17,36 +15,18 @@ import java.util.List;
 
 public class ReputationReloadCommand implements CommandExecutor, TabCompleter
 {
-    private static final MiniMessage mm = MiniMessage.miniMessage();
-
-    private static @NotNull String rc(String target) {
-        return ChatColor.translateAlternateColorCodes('&', target);
-    }
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-        boolean isPlayer = sender instanceof Player;
-        Audience audience = null;
-
-        if (isPlayer) audience = (Audience)sender;
+        Audience audience = (Audience) sender;
 
         if (args.length == 0) {
             Main.reload();
-            if (isPlayer) {
-                audience.sendMessage(mm.deserialize(ChatColor.stripColor(Files.Config.REPUTATIONRELOAD_CMD_RELOADED)));
-                return true;
-            }
-
-            sender.sendMessage(rc(mm.stripTags(Files.Config.REPUTATIONRELOAD_CMD_RELOADED)));
+            audience.sendMessage(Files.message("commands.reputationreload.reloaded", Files.Config.REPUTATIONRELOAD_CMD_RELOADED));
             return true;
         }
 
-        if (isPlayer) {
-            audience.sendMessage(mm.deserialize(ChatColor.stripColor(Files.Config.REPUTATIONRELOAD_CMD_USAGE)));
-            return true;
-        }
-
-        sender.sendMessage(rc(mm.stripTags(Files.Config.REPUTATIONRELOAD_CMD_USAGE)));
+        audience.sendMessage(Files.message("commands.reputationreload.usage", Files.Config.REPUTATIONRELOAD_CMD_USAGE));
         return true;
     }
 

--- a/src/main/java/net/xdproston/tiderep/impl/MySQL.java
+++ b/src/main/java/net/xdproston/tiderep/impl/MySQL.java
@@ -1,31 +1,17 @@
 package net.xdproston.tiderep.impl;
 
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
+import com.j256.ormlite.jdbc.JdbcConnectionSource;
 import net.xdproston.tiderep.Files;
-import net.xdproston.tiderep.interfaces.Database;
-import net.xdproston.tiderep.logger.Logger;
-import net.xdproston.tiderep.logger.LoggerType;
 
-public class MySQL extends SQLite implements Database
-{
+public class MySQL extends OrmLiteDatabase {
     @Override
-    public void init() {
-        try {
-            HikariConfig hc = new HikariConfig();
-            hc.setPoolName("MySQL");
-            hc.setDriverClassName("com.mysql.cj.jdbc.Driver");
-            hc.setJdbcUrl(String.format("jdbc:mysql://%s/%s", Files.Config.DATABASE_MYSQL_IP_AND_PORT, Files.Config.DATABASE_MYSQL_USE_DB));
-            hc.setUsername(Files.Config.DATABASE_MYSQL_USER);
-            hc.setPassword(Files.Config.DATABASE_MYSQL_PASSWORD);
+    protected String connectionString() {
+        return String.format("jdbc:mysql://%s/%s", Files.Config.DATABASE_MYSQL_IP_AND_PORT, Files.Config.DATABASE_MYSQL_USE_DB);
+    }
 
-            hds = new HikariDataSource(hc);
-            connect = hds.getConnection();
-            stmt = connect.createStatement();
-        } catch (Exception e) {
-            Logger.send(LoggerType.SEVERE, "An error occurred during the connection of the mysql database:" + String.format("%s - %s", e.getClass().getName(), e.getMessage()));
-        }
-
-        execute(stmt, "CREATE TABLE IF NOT EXISTS users(name VARCHAR(256) UNIQUE NOT NULL, reputation INT NOT NULL, sends LONGTEXT);");
+    @Override
+    protected void configureConnection(JdbcConnectionSource source) {
+        source.setUsername(Files.Config.DATABASE_MYSQL_USER);
+        source.setPassword(Files.Config.DATABASE_MYSQL_PASSWORD);
     }
 }

--- a/src/main/java/net/xdproston/tiderep/impl/OrmLiteDatabase.java
+++ b/src/main/java/net/xdproston/tiderep/impl/OrmLiteDatabase.java
@@ -1,0 +1,135 @@
+package net.xdproston.tiderep.impl;
+
+import com.j256.ormlite.dao.Dao;
+import com.j256.ormlite.jdbc.JdbcConnectionSource;
+import com.j256.ormlite.table.TableUtils;
+import net.xdproston.tiderep.Files;
+import net.xdproston.tiderep.User;
+import net.xdproston.tiderep.interfaces.Database;
+import net.xdproston.tiderep.logger.Logger;
+import net.xdproston.tiderep.logger.LoggerType;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+
+public abstract class OrmLiteDatabase implements Database {
+    protected JdbcConnectionSource connection;
+    protected Dao<User, String> userDao;
+
+    protected abstract String connectionString();
+
+    protected abstract void configureConnection(JdbcConnectionSource source);
+
+    @Override
+    public void init() {
+        try {
+            connection = new JdbcConnectionSource(connectionString());
+            configureConnection(connection);
+            userDao = com.j256.ormlite.dao.DaoManager.createDao(connection, User.class);
+            TableUtils.createTableIfNotExists(connection, User.class);
+        } catch (Exception e) {
+            Logger.send(LoggerType.SEVERE, "Database init error:", e.getMessage());
+        }
+    }
+
+    @Override
+    public boolean hasPlayerInDatabase(Player target) {
+        try {
+            return userDao.idExists(target.getName());
+        } catch (Exception e) {
+            Logger.send(LoggerType.SEVERE, "SQL error:", e.getMessage());
+            return false;
+        }
+    }
+
+    @Override
+    public void addPlayerToDatabase(Player target) {
+        try {
+            userDao.createIfNotExists(new User(target.getName(), Files.Config.STARTUP_REPUTATION, "NONE"));
+        } catch (Exception e) {
+            Logger.send(LoggerType.SEVERE, "SQL error:", e.getMessage());
+        }
+    }
+
+    @Override
+    public int getPlayerReputation(Player target) {
+        try {
+            User u = userDao.queryForId(target.getName());
+            return u != null ? u.getReputation() : 0;
+        } catch (Exception e) {
+            Logger.send(LoggerType.SEVERE, "SQL error:", e.getMessage());
+            return 0;
+        }
+    }
+
+    @Override
+    public void addPlayerToSends(Player target, Player player) {
+        try {
+            User u = userDao.queryForId(target.getName());
+            if (u == null) return;
+            String sends = u.getSends();
+            if (sends == null || sends.equalsIgnoreCase("NONE")) {
+                u.setSends(player.getName());
+            } else {
+                u.setSends(sends + ", " + player.getName());
+            }
+            userDao.update(u);
+        } catch (Exception e) {
+            Logger.send(LoggerType.SEVERE, "SQL error:", e.getMessage());
+        }
+    }
+
+    @Override
+    public boolean containsPlayerInSends(Player target, Player player) {
+        try {
+            User u = userDao.queryForId(target.getName());
+            if (u == null) return false;
+            String sends = u.getSends();
+            if (sends == null) return false;
+            for (String name : sends.split(", ")) {
+                if (name.equalsIgnoreCase(player.getName())) {
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            Logger.send(LoggerType.SEVERE, "SQL error:", e.getMessage());
+        }
+        return false;
+    }
+
+    @Override
+    public ArrayList<String> getPlayerNamesInDatabase() {
+        try {
+            ArrayList<String> list = new ArrayList<>();
+            for (User u : userDao.queryForAll()) {
+                list.add(u.getName());
+            }
+            return list;
+        } catch (Exception e) {
+            Logger.send(LoggerType.SEVERE, "SQL error:", e.getMessage());
+        }
+        return new ArrayList<>();
+    }
+
+    @Override
+    public void setPlayerReputation(Player target, int reputation) {
+        try {
+            User u = userDao.queryForId(target.getName());
+            if (u != null) {
+                u.setReputation(reputation);
+                userDao.update(u);
+            }
+        } catch (Exception e) {
+            Logger.send(LoggerType.SEVERE, "SQL error:", e.getMessage());
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            if (connection != null) connection.close();
+        } catch (Exception e) {
+            Logger.send(LoggerType.SEVERE, "Error closing database:", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/net/xdproston/tiderep/impl/SQLite.java
+++ b/src/main/java/net/xdproston/tiderep/impl/SQLite.java
@@ -1,129 +1,16 @@
 package net.xdproston.tiderep.impl;
 
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
-import net.xdproston.tiderep.Files;
+import com.j256.ormlite.jdbc.JdbcConnectionSource;
 import net.xdproston.tiderep.Main;
-import net.xdproston.tiderep.interfaces.Database;
-import net.xdproston.tiderep.logger.Logger;
-import net.xdproston.tiderep.logger.LoggerType;
-import org.bukkit.entity.Player;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.Statement;
-import java.util.ArrayList;
 
-public class SQLite implements Database
-{
-    private static final String DB_PATH_STR = "jdbc:sqlite:" + Main.getInstance().getDataFolder().getAbsolutePath() + "/users.db";
-
-    protected HikariDataSource hds;
-    protected Connection connect;
-    protected Statement stmt;
-
+public class SQLite extends OrmLiteDatabase {
     @Override
-    public void init() {
-        try {
-            HikariConfig hc = new HikariConfig();
-            hc.setPoolName("SQLite");
-            hc.setDriverClassName("org.sqlite.JDBC");
-            hc.setJdbcUrl(DB_PATH_STR);
-
-            hds = new HikariDataSource(hc);
-            connect = hds.getConnection();
-            stmt = connect.createStatement();
-        } catch (Exception e) {
-            Logger.send(LoggerType.SEVERE, "An error occurred during the connection of the sqlite database:" + String.format("%s - %s", e.getClass().getName(), e.getMessage()));
-        }
-
-        execute(stmt, "CREATE TABLE IF NOT EXISTS users(\"name\" TEXT UNIQUE NOT NULL, \"reputation\" INT NOT NULL, \"sends\" TEXT DEFAULT 'NONE');");
+    protected String connectionString() {
+        return "jdbc:sqlite:" + Main.getInstance().getDataFolder().getAbsolutePath() + "/users.db";
     }
 
     @Override
-    public boolean hasPlayerInDatabase(Player target) {
-        try (ResultSet rs = executeQuery(stmt, String.format("SELECT EXISTS(SELECT name FROM users WHERE name = '%s');", target.getName()))) {
-            return rs != null && rs.getString(1).equalsIgnoreCase("1");
-        }
-        catch (Exception e) {
-            Logger.send(LoggerType.SEVERE, "An error occurred during the execution of the sql script:" + String.format("%s - %s", e.getClass().getName(), e.getMessage()));
-        }
-        return false;
-    }
-
-    @Override
-    public void addPlayerToDatabase(Player target) {
-        execute(stmt, String.format("INSERT INTO users(name, reputation) VALUES('%s', %d);", target.getName(), Files.Config.STARTUP_REPUTATION));
-    }
-
-    @Override
-    public int getPlayerReputation(Player target) {
-        try (ResultSet rs = executeQuery(stmt, String.format("SELECT reputation FROM users WHERE name = '%s';", target.getName()))) {
-            return rs != null ? rs.getInt(1) : 0;
-        }
-        catch (Exception e) {
-            Logger.send(LoggerType.SEVERE, "An error occurred during the execution of the sql script:" + String.format("%s - %s", e.getClass().getName(), e.getMessage()));
-        }
-        return -927817563;
-    }
-
-    @Override
-    public void addPlayerToSends(Player target, Player player) {
-        try (ResultSet rs = executeQuery(stmt, String.format("SELECT sends FROM users WHERE name = '%s';", target.getName()))) {
-            String sends = rs != null ? rs.getString(1) : null;
-
-            if (sends != null && sends.equalsIgnoreCase("NONE")) {
-                execute(stmt, String.format("UPDATE users SET sends = '%s' WHERE name = '%s';", player.getName(), target.getName()));
-            } else {
-                execute(stmt, String.format("UPDATE users SET sends = '%s, %s' WHERE name = '%s';", sends, player.getName(), target.getName()));
-            }
-        }
-        catch (Exception e) {
-            Logger.send(LoggerType.SEVERE, "An error occurred during the execution of the sql script:" + String.format("%s - %s", e.getClass().getName(), e.getMessage()));
-        }
-    }
-
-    @Override
-    public boolean containsPlayerInSends(Player target, Player player) {
-        try (ResultSet rs = executeQuery(stmt, String.format("SELECT sends FROM users WHERE name = '%s';", target.getName()))) {
-            String sends = rs != null ? rs.getString(1) : null;
-
-            String[] listOfSends = sends != null ? sends.split(", ") : new String[0];
-            for (String name : listOfSends) {
-                if (player.getName().equalsIgnoreCase(name)) return true;
-            }
-        }
-        catch (Exception e) {
-            Logger.send(LoggerType.SEVERE, "An error occurred during the execution of the sql script:" + String.format("%s - %s", e.getClass().getName(), e.getMessage()));
-        }
-        return false;
-    }
-
-    @Override
-    public ArrayList<String> getPlayerNamesInDatabase() {
-        try (ResultSet rs = executeQuery(stmt, "SELECT name FROM users;")) {
-            ArrayList<String> list = new ArrayList<>();
-            do {list.add(rs != null ? rs.getString(1) : null);} while (rs != null && rs.next());
-
-            return list;
-        }
-        catch (Exception e) {
-            Logger.send(LoggerType.SEVERE, "An error occurred during the execution of the sql script:" + String.format("%s - %s", e.getClass().getName(), e.getMessage()));
-        }
-        return null;
-    }
-
-    @Override
-    public void setPlayerReputation(Player target, int reputation) {
-        execute(stmt, String.format("UPDATE users SET reputation = %d WHERE name = '%s';", reputation, target.getName()));
-    }
-
-    @Override
-    public void close() {
-        try {
-            if (stmt != null) stmt.close();
-            if (connect != null) connect.close();
-        } catch (Exception e) {
-            Logger.send(LoggerType.SEVERE, "An error occurred while closing the database:" + String.format("%s - %s", e.getClass().getName(), e.getMessage()));
-        }
+    protected void configureConnection(JdbcConnectionSource source) {
+        // no additional configuration
     }
 }

--- a/src/main/java/net/xdproston/tiderep/interfaces/Database.java
+++ b/src/main/java/net/xdproston/tiderep/interfaces/Database.java
@@ -1,27 +1,10 @@
 package net.xdproston.tiderep.interfaces;
 
-import net.xdproston.tiderep.logger.Logger;
-import net.xdproston.tiderep.logger.LoggerType;
 import org.bukkit.entity.Player;
-import java.sql.ResultSet;
-import java.sql.Statement;
+
 import java.util.ArrayList;
 
-public interface Database
-{
-    default void execute(Statement stmt, String sql) {
-        try { stmt.execute(sql);
-        } catch (Exception e) {
-            Logger.send(LoggerType.SEVERE, "An error occurred while executing sql script:" + String.format("%s - %s", e.getClass().getName(), e.getMessage()));
-        }
-    }
-    default ResultSet executeQuery(Statement stmt, String sql) {
-        try { return stmt.executeQuery(sql);}
-        catch (Exception e) {
-            Logger.send(LoggerType.SEVERE, "An error occurred during while executing sql script:" + String.format("%s - %s", e.getClass().getName(), e.getMessage()));
-        }
-        return null;
-    }
+public interface Database {
     void init();
     boolean hasPlayerInDatabase(Player target);
     void addPlayerToDatabase(Player target);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,12 +1,13 @@
 name: TideReputation
 author: xdproston
 version: 1.3
-api-version: 1.13
+api-version: 1.19
 libraries:
   - net.kyori:adventure-text-minimessage:4.14.0
   - org.xerial:sqlite-jdbc:3.8.11.2
   - com.zaxxer:HikariCP:5.1.0
   - mysql:mysql-connector-java:8.0.33
+  - com.j256.ormlite:ormlite-jdbc:6.1
 depend: [PlaceholderAPI]
 main: net.xdproston.tiderep.Main
 commands:


### PR DESCRIPTION
## Summary
- migrate build to Paper API
- introduce ORMLite-based database layer
- add Lombok and new `User` entity
- rewrite commands using MiniMessage and Brigadier parsing
- update PlaceholderAPI hook
- update plugin metadata
- simplify config defaults and add MiniMessage helper

## Testing
- `mvn -DskipTests install`


------
https://chatgpt.com/codex/tasks/task_b_687669595d48832884bbc0bbc50e6ba8